### PR TITLE
Claim typeorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Submit a PR to add the package you want to the list, so that others could help w
   + Status: __NOT AVAILABLE__
   + Claimed: Not yet
 - [ ] [typeorm](https://github.com/typeorm/typeorm)
+  + Status: __IN PROGRESS__
+  + Claimed: [uki00a/typeorm](https://github.com/uki00a/typeorm)
 - [ ] [pako](https://github.com/nodeca/pako)
   + Status: __NOT AVAILABLE__
   + Claimed: Not yet


### PR DESCRIPTION
I'm trying to port [typeorm](https://github.com/typeorm/typeorm) to deno.

I want to move it to [denolib/typeorm](https://github.com/denolib/typeorm) when it's more stable.