### PR TITLE
Update GraphQL status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Submit a PR to add the package you want to the list, so that others could help w
   + Status: __IN PROGRESS__
   + Claimed: [eliassjogreen/denon](https://github.com/eliassjogreen/denon)
 - [ ] [graphql-js](https://github.com/graphql/graphql-js)
-  + Status: __NOT AVAILABLE__
-  + Claimed: Not yet
+  + Status: __COMPLETED__
+  + Claimed: [adelsz/graphql-deno)](https://github.com/adelsz/graphql-deno)
 - [ ] [loopback](https://github.com/strongloop/loopback)
   + Status: __NOT AVAILABLE__
   + Claimed: Not yet


### PR DESCRIPTION
GraphQL had been ported to Deno long ago so the list should be updated

Link: https://github.com/adelsz/graphql-deno